### PR TITLE
Add version and status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # virtualgym-agent
 
+![Version](https://img.shields.io/badge/version-0.2-blue)
+![Python](https://img.shields.io/badge/python-3.12-blue)
+![License](https://img.shields.io/github/license/troyscott/virtualgym-agent)
+![Issues](https://img.shields.io/github/issues/troyscott/virtualgym-agent)
+![PRs](https://img.shields.io/github/issues-pr/troyscott/virtualgym-agent)
+
 Automated workout data extraction from [VirtuaGym](https://virtuagym.com) using Vercel's [agent-browser](https://github.com/vercel-labs/agent-browser). Extracts exercises, sets, reps, and weights — then generates structured JSON, text reports, and Instagram-ready images (1080x1350).
 
 Works standalone via CLI, or integrated with Claude Channels, OpenClaw, and other AI agent frameworks.


### PR DESCRIPTION
## Summary
- Adds shields.io badges to README header: version (v0.2), Python 3.12, license, open issues, open PRs
- Version badge is static — update manually with each release
- Issues/PRs badges are dynamic from GitHub

## Test plan
- [ ] View README on GitHub and verify badges render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)