### PR TITLE
docs: Chrome profile workaround for VirtuaGym CAPTCHA loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,27 @@ agent-browser state save ./virtuagym-auth.json
 agent-browser state load ./virtuagym-auth.json
 ```
 
+### CAPTCHA workaround (Chrome profile reuse)
+
+VirtuaGym fingerprints the browser and serves an aggressive, looping CAPTCHA to fresh Chromium instances launched by `agent-browser`. Saved-password autofill won't help — the CAPTCHA fires before submit. To get past it, reuse a real Chrome profile so the site sees your existing fingerprint, history, and extensions:
+
+```bash
+# 1. List your local Chrome profiles
+agent-browser profiles
+
+# 2. Fully QUIT Chrome (Cmd+Q) — a profile can't be open in two browsers at once
+# 3. Launch agent-browser with that profile and sign in once in the headed window
+agent-browser close --all
+agent-browser --headed --profile "Profile 2" open https://thriveandconquer.virtuagym.com/signin
+# (sign in manually — your Chrome password manager will autofill)
+
+# 4. Save fresh state and shut down
+agent-browser state save ./virtuagym-auth.json
+agent-browser close --all
+```
+
+Once `virtuagym-auth.json` is fresh, `extract_workout.py` runs headless against the saved state without needing the profile again — until the session expires (~30 days).
+
 ## Extraction Workflow
 
 The `extract_workout.py` script automates the full pipeline:


### PR DESCRIPTION
## Summary

- Documents the Chrome profile reuse path in CLAUDE.md after the standard `agent-browser --headed` login was blocked by an aggressive looping CAPTCHA on a fresh-fingerprint Chromium.
- Hit during yesterday's extraction (2026-05-01) when saved auth from Apr 5 expired — full diagnostic and proposed permanent fixes are in #12.

Closes nothing on its own — issue #12 stays open to track a code-level fix.

## Test plan

- [x] Followed the new instructions end-to-end against a freshly-quit Chrome on Profile 2 — login succeeded, `state save` produced a valid `virtuagym-auth.json`, and `extract_workout.py yesterday` ran cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts the manual auth workflow; no code or runtime behavior changes.
> 
> **Overview**
> Documents a new manual authentication workaround in `CLAUDE.md` for VirtuaGym’s looping CAPTCHA by reusing an existing Chrome profile with `agent-browser --profile`, then saving a refreshed `virtuagym-auth.json` for subsequent headless runs.
> 
> Adds step-by-step commands for listing profiles, ensuring Chrome is fully quit, running a headed login with the chosen profile, and persisting browser state until the session expires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c6ef8a729b32287a6a73096fce6aeb3a8352312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->