### PR TITLE
Add extract.sh + on-demand launchd job for Cowork Dispatch from iPhone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ data/*
 images/*
 !images/.gitkeep
 
+# launchd job logs
+logs/
+
 # Fonts tracked in repo (Poppins, OFL licensed)
 
 # Legacy Cowork/Chrome MCP prompts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,38 @@ Config lives in `config.json` (committed, no secrets); resolution is env var > `
 default. Keys: `CHROME_BIN`, `CHROME_PROFILE_DIR` (default `~/.virtuagym-chrome`), `CDP_PORT`
 (default `9222`), plus the VirtuaGym URLs / Google account.
 
+## Running from iPhone (Cowork Dispatch)
+
+Dispatch executes **on this Mac mini** (the phone is just the remote control), so it has full
+access to the local Chrome profile and `localhost:9222` — unlike cloud agents/routines, which are
+isolated and cannot run this workflow.
+
+`extract.sh` is the single command both the phone and launchd use:
+
+```bash
+./extract.sh            # most recent workout (default)
+./extract.sh today
+./extract.sh 2026-06-05
+```
+
+The extraction is registered as an **on-demand launchd job** (no timer) so it can be triggered and
+monitored via `launchctl` — the natural surface for Dispatch and for a status artifact:
+
+```bash
+scripts/launchd.sh install     # register the job (one-time)
+scripts/launchd.sh run-now     # trigger an extraction (launchctl kickstart)
+scripts/launchd.sh status      # load state / last exit code / pid
+scripts/launchd.sh logs [N]    # tail logs (default 40 lines) -> logs/extract.{out,err}.log
+scripts/launchd.sh uninstall
+```
+
+**Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh run-now`,
+then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."*
+
+Requirements: the Mac mini stays awake/networked and Claude Desktop is running and signed in. If the
+Google session ever dies, the headless run can't solve the login unattended — re-run
+`python browser_session.py --login` once at the machine.
+
 ## Extraction Workflow
 
 The `extract_workout.py` script automates the full pipeline:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,38 @@ Config lives in `config.json` (committed, no secrets); resolution is env var > `
 default. Keys: `CHROME_BIN`, `CHROME_PROFILE_DIR` (default `~/.virtuagym-chrome`), `CDP_PORT`
 (default `9222`), plus the VirtuaGym URLs / Google account.
 
+## Running from iPhone (Cowork Dispatch)
+
+Dispatch executes **on this Mac mini** (the phone is just the remote control), so it has full
+access to the local Chrome profile and `localhost:9222` — unlike cloud agents/routines, which are
+isolated and cannot run this workflow.
+
+`extract.sh` is the single command both the phone and launchd use:
+
+```bash
+./extract.sh            # most recent workout (default)
+./extract.sh today
+./extract.sh 2026-06-05
+```
+
+The extraction is registered as an **on-demand launchd job** (no timer) so it can be triggered and
+monitored via `launchctl` — the natural surface for Dispatch and for a status artifact:
+
+```bash
+scripts/launchd.sh install     # register the job (one-time)
+scripts/launchd.sh run-now     # trigger an extraction (launchctl kickstart)
+scripts/launchd.sh status      # load state / last exit code / pid
+scripts/launchd.sh logs [N]    # tail logs (default 40 lines) -> logs/extract.{out,err}.log
+scripts/launchd.sh uninstall
+```
+
+**Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh run-now`,
+then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."*
+
+Requirements: the Mac mini stays awake/networked and Claude Desktop is running and signed in. If the
+Google session ever dies, the headless run can't solve the login unattended — re-run
+`python browser_session.py --login` once at the machine.
+
 ## Extraction Workflow
 
 The `extract_workout.py` script automates the full pipeline:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ python3 extract_workout.py yesterday
 python3 extract_workout.py "Mar 21"
 ```
 
+### Run from your phone (Cowork Dispatch)
+
+`extract.sh` wraps the command so it works from a single entry point, and the extraction can be
+registered as an on-demand launchd job and triggered/monitored via `launchctl` — ideal for Cowork
+Dispatch, which runs locally on the Mac and so can reach the Chrome profile + `localhost:9222`:
+
+```bash
+./extract.sh                   # most recent workout
+scripts/launchd.sh install     # register the on-demand launchd job (one-time)
+scripts/launchd.sh run-now     # trigger it; logs -> logs/extract.{out,err}.log
+scripts/launchd.sh status      # load state / last exit code
+scripts/launchd.sh logs        # tail recent output
+```
+
 The script will:
 1. Load saved auth and open the VirtuaGym Activity Calendar
 2. Navigate to the target date

--- a/extract.sh
+++ b/extract.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Thin wrapper so the phone (Cowork Dispatch) and launchd can run the
+# extraction with a single, environment-independent command:
+#
+#     ./extract.sh            # most recent workout (default)
+#     ./extract.sh today
+#     ./extract.sh 2026-06-05
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# launchd runs jobs with a minimal PATH; agent-browser lives in Homebrew's bin.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+# Python from the micromamba `workout` env. Override with WORKOUT_PYTHON if this
+# path changes (e.g. after a micromamba upgrade recreates the env).
+PYTHON="${WORKOUT_PYTHON:-/opt/homebrew/Cellar/micromamba/2.5.0_4/envs/workout/bin/python}"
+
+if [ ! -x "$PYTHON" ]; then
+    echo "Python interpreter not found: $PYTHON" >&2
+    echo "Set WORKOUT_PYTHON to the 'workout' env python and retry." >&2
+    exit 1
+fi
+
+exec "$PYTHON" extract_workout.py "${1:-last}"

--- a/scripts/launchd.sh
+++ b/scripts/launchd.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Manage the VirtuaGym extraction as an on-demand launchd job (LaunchAgent).
+#
+# The job has no timed trigger — it runs only when you kick it off, which is
+# ideal for triggering from the phone via Cowork Dispatch. Dispatch runs
+# locally, so it can call any of these subcommands:
+#
+#     scripts/launchd.sh install     # register the job with launchd
+#     scripts/launchd.sh run-now     # trigger an extraction now
+#     scripts/launchd.sh status      # show load state / last exit code / pid
+#     scripts/launchd.sh logs [N]    # tail the last N log lines (default 40)
+#     scripts/launchd.sh uninstall   # remove the job
+#
+set -euo pipefail
+
+LABEL="com.troyscott.virtualgym.extract"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO/logs"
+PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DOMAIN="gui/$(id -u)"
+
+gen_plist() {
+    mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+    cat > "$PLIST_DST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$REPO/extract.sh</string>
+        <string>last</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>$REPO</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>$LOG_DIR/extract.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>$LOG_DIR/extract.err.log</string>
+</dict>
+</plist>
+PLIST
+}
+
+case "${1:-}" in
+    install)
+        gen_plist
+        launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+        launchctl bootstrap "$DOMAIN" "$PLIST_DST"
+        echo "Installed $LABEL (on-demand)."
+        echo "Trigger it with: $0 run-now"
+        ;;
+    uninstall)
+        launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
+        rm -f "$PLIST_DST"
+        echo "Uninstalled $LABEL."
+        ;;
+    run-now)
+        launchctl kickstart -k "$DOMAIN/$LABEL"
+        echo "Triggered $LABEL. Follow output with: $0 logs"
+        ;;
+    status)
+        if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+            launchctl print "$DOMAIN/$LABEL" \
+                | grep -E "^\s*(state|pid|last exit code) " || true
+        else
+            echo "$LABEL is not loaded (run: $0 install)"
+        fi
+        ;;
+    logs)
+        n="${2:-40}"
+        for f in "$LOG_DIR/extract.out.log" "$LOG_DIR/extract.err.log"; do
+            echo "=== ${f##*/} ==="
+            tail -n "$n" "$f" 2>/dev/null || echo "(none yet)"
+        done
+        ;;
+    *)
+        echo "Usage: $0 {install|uninstall|run-now|status|logs [N]}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Why

Make triggering the workout extraction from the **iPhone (Cowork Dispatch)** dead simple. Dispatch runs **locally on the Mac mini** (the phone is just a remote control), so it has full access to the persistent Chrome profile and `localhost:9222` — unlike cloud agents/routines, which run in isolated VMs and cannot reach local Chrome.

## What

- **`extract.sh`** — single entry point both the phone and launchd use. Resolves the `workout` env Python and sets a launchd-safe PATH (so `agent-browser` is found under launchd's minimal environment). Optional date arg, defaults to `last`.
- **`scripts/launchd.sh`** — manage an **on-demand LaunchAgent** (no timer) via `install` / `uninstall` / `run-now` / `status` / `logs`. This is the `launchctl` surface Dispatch can drive from the phone, and that a status artifact can render from. Triggered with `launchctl kickstart`.
- **Docs** (README / CLAUDE / AGENTS) — "Running from iPhone (Cowork Dispatch)" recipe + management commands.
- **`.gitignore`** — `logs/`.

## Phone recipe

> "In virtualgym-agent, run `scripts/launchd.sh run-now`, then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."

## Verified

`scripts/launchd.sh install` + `run-now` ran the full **headless** extraction under launchd's minimal environment and exited **0** — found the latest workout, clicked all 15 exercises, generated JSON + report + IG image.

## Notes

- On-demand only: no `StartCalendarInterval`, `RunAtLoad=false` (matches "phone-only, no schedule").
- Requires the Mac mini awake/networked + Claude Desktop running. If the Google session dies, the unattended headless run can't solve login — re-run `python browser_session.py --login` once at the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational wrapper and documentation only; no changes to extraction, auth, or data handling in Python.
> 
> **Overview**
> Adds a **phone-friendly local trigger path** for workout extraction via Cowork Dispatch on the Mac mini, without changing the core Python extraction logic.
> 
> **`extract.sh`** is a new single entry point that sets a launchd-safe `PATH`, resolves the micromamba `workout` Python (overridable via `WORKOUT_PYTHON`), and delegates to `extract_workout.py` with an optional date arg (defaults to **`last`**).
> 
> **`scripts/launchd.sh`** registers an **on-demand** LaunchAgent (`RunAtLoad=false`, no schedule) that runs `extract.sh last`, with `install` / `run-now` (`launchctl kickstart`) / `status` / `logs` / `uninstall` and stdout/stderr under **`logs/`** (now gitignored).
> 
> **README**, **AGENTS.md**, and **CLAUDE.md** document the iPhone Dispatch workflow and the launchctl commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39711c4e1a4cf4c756045fe8b8fe6b75ba7e567c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->