### PR TITLE
Add launchd status dashboard (status.py + live-artifact HTML)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,12 @@ scripts/launchd.sh logs [N]    # tail logs (default 40 lines) -> logs/extract.{o
 scripts/launchd.sh uninstall
 ```
 
+**Status dashboard (live artifact):** `scripts/status.py` emits JSON for every `com.troyscott.*`
+launchd job (load state, last exit code, last run, log tail) plus the latest workout summary.
+`scripts/dashboard.sh` injects that JSON into `scripts/dashboard.html` and writes a self-contained
+`logs/dashboard.html` — open it, send it to the phone, or surface it as a Cowork live artifact.
+Re-run `dashboard.sh` (via Dispatch) to refresh; the artifact displays, Dispatch executes.
+
 **Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh run-now`,
 then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ scripts/launchd.sh logs [N]    # tail logs (default 40 lines) -> logs/extract.{o
 scripts/launchd.sh uninstall
 ```
 
+**Status dashboard (live artifact):** `scripts/status.py` emits JSON for every `com.troyscott.*`
+launchd job (load state, last exit code, last run, log tail) plus the latest workout summary.
+`scripts/dashboard.sh` injects that JSON into `scripts/dashboard.html` and writes a self-contained
+`logs/dashboard.html` — open it, send it to the phone, or surface it as a Cowork live artifact.
+Re-run `dashboard.sh` (via Dispatch) to refresh; the artifact displays, Dispatch executes.
+
 **Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh run-now`,
 then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."*
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,12 @@ scripts/launchd.sh install     # register the on-demand launchd job (one-time)
 scripts/launchd.sh run-now     # trigger it; logs -> logs/extract.{out,err}.log
 scripts/launchd.sh status      # load state / last exit code
 scripts/launchd.sh logs        # tail recent output
+scripts/dashboard.sh           # render logs/dashboard.html status dashboard (live artifact)
 ```
+
+`scripts/status.py` emits JSON for every `com.troyscott.*` launchd job plus the latest workout
+summary; `scripts/dashboard.sh` injects it into a self-contained HTML dashboard you can view, send to
+your phone, or surface as a Cowork live artifact.
 
 The script will:
 1. Load saved auth and open the VirtuaGym Activity Calendar

--- a/scripts/dashboard.html
+++ b/scripts/dashboard.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>VirtuaGym launchd status</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 24px;
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0f1115; color: #e6e8eb;
+  }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .meta { color: #8b9097; font-size: 13px; margin-bottom: 20px; }
+  .card {
+    background: #171a21; border: 1px solid #242832; border-radius: 12px;
+    padding: 16px 18px; margin-bottom: 16px;
+  }
+  .row { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+  .label { font-weight: 600; font-size: 16px; }
+  .badge {
+    font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 999px;
+    text-transform: uppercase; letter-spacing: .4px;
+  }
+  .ok { background: #103a24; color: #4ade80; }
+  .bad { background: #3a1414; color: #f87171; }
+  .idle { background: #2a2f3a; color: #9aa3b2; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px,1fr)); gap: 10px; margin-top: 12px; }
+  .stat { background: #0f1218; border: 1px solid #222633; border-radius: 8px; padding: 8px 10px; }
+  .stat .k { color: #8b9097; font-size: 11px; text-transform: uppercase; letter-spacing: .4px; }
+  .stat .v { font-size: 15px; font-weight: 600; margin-top: 2px; }
+  pre {
+    background: #0b0d11; border: 1px solid #222633; border-radius: 8px;
+    padding: 12px; overflow: auto; font-size: 12px; color: #aab2c0; margin: 12px 0 0;
+    max-height: 220px; white-space: pre-wrap;
+  }
+  .empty { color: #8b9097; }
+  code { background: #0b0d11; padding: 1px 6px; border-radius: 5px; }
+</style>
+</head>
+<body>
+<h1>VirtuaGym &middot; launchd status</h1>
+<div class="meta" id="meta"></div>
+<div id="jobs"></div>
+<div id="workout"></div>
+
+<script>
+// dashboard.sh replaces the token below with live `status.py` JSON.
+const DATA = __STATUS_JSON__;
+
+function esc(s) {
+  return String(s == null ? "" : s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+}
+function ago(iso) {
+  if (!iso) return "never";
+  const secs = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (secs < 90) return Math.round(secs) + "s ago";
+  if (secs < 5400) return Math.round(secs / 60) + "m ago";
+  if (secs < 172800) return Math.round(secs / 3600) + "h ago";
+  return Math.round(secs / 86400) + "d ago";
+}
+function exitBadge(job) {
+  if (!job.loaded) return '<span class="badge idle">not loaded</span>';
+  if (job.state && job.state.indexOf("running") >= 0 && job.pid)
+    return '<span class="badge idle">running</span>';
+  if (job.last_exit_code === 0) return '<span class="badge ok">exit 0</span>';
+  if (job.last_exit_code == null) return '<span class="badge idle">never run</span>';
+  return '<span class="badge bad">exit ' + esc(job.last_exit_code) + '</span>';
+}
+
+document.getElementById("meta").textContent =
+  DATA.host + " · generated " + ago(DATA.generated_at);
+
+document.getElementById("jobs").innerHTML = (DATA.jobs || []).map(job => `
+  <div class="card">
+    <div class="row">
+      <span class="label">${esc(job.label)}</span>
+      ${exitBadge(job)}
+    </div>
+    <div class="grid">
+      <div class="stat"><div class="k">State</div><div class="v">${esc(job.state || "—")}</div></div>
+      <div class="stat"><div class="k">Last run</div><div class="v">${esc(ago(job.last_run))}</div></div>
+      <div class="stat"><div class="k">PID</div><div class="v">${esc(job.pid || "—")}</div></div>
+    </div>
+    ${job.log_tail ? `<pre>${esc(job.log_tail)}</pre>` : '<p class="empty">No log output yet.</p>'}
+  </div>
+`).join("") || '<p class="empty">No launchd jobs found.</p>';
+
+const w = DATA.latest_workout;
+document.getElementById("workout").innerHTML = w ? `
+  <div class="card">
+    <div class="row"><span class="label">Latest workout</span>
+      <span class="badge idle">${esc(w.date)} · ${esc(w.day_of_week || "")}</span></div>
+    <p style="margin:8px 0 0">${esc(w.title || "")}</p>
+    <div class="grid">
+      <div class="stat"><div class="k">Exercises</div><div class="v">${esc(w.total_exercises ?? "—")}</div></div>
+      <div class="stat"><div class="k">Calories</div><div class="v">${esc(w.total_calories ?? "—")}</div></div>
+      <div class="stat"><div class="k">Volume (lbs)</div><div class="v">${esc((w.total_volume_lbs ?? 0).toLocaleString())}</div></div>
+    </div>
+    ${w.image_path ? `<p class="empty" style="margin-top:12px">Image: <code>${esc(w.image_path)}</code></p>` : ""}
+  </div>` : "";
+</script>
+</body>
+</html>

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Render the launchd status dashboard by injecting live status.py JSON into the
+# dashboard.html template. The result is a self-contained HTML file you can open,
+# send to your phone, or surface as a Cowork live artifact.
+#
+#     scripts/dashboard.sh                 # -> logs/dashboard.html
+#     scripts/dashboard.sh /tmp/dash.html  # custom output path
+#
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:-$REPO/logs/dashboard.html}"
+mkdir -p "$(dirname "$OUT")"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+python3 "$REPO/scripts/status.py" > "$TMP"
+
+python3 - "$REPO/scripts/dashboard.html" "$TMP" "$OUT" <<'PY'
+import sys, pathlib
+template, datafile, out = sys.argv[1], sys.argv[2], sys.argv[3]
+data = pathlib.Path(datafile).read_text().strip()
+html = pathlib.Path(template).read_text().replace("__STATUS_JSON__", data)
+pathlib.Path(out).write_text(html)
+PY
+
+echo "Wrote $OUT"

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Emit JSON status for launchd job(s) so a live artifact (or any UI) can render it.
+
+Usage:
+    scripts/status.py [LABEL ...]
+
+With no args, reports every ``com.troyscott.*`` LaunchAgent found in
+~/Library/LaunchAgents. Output is JSON on stdout — pair it with dashboard.sh to
+render the HTML dashboard, or consume it directly from Cowork Dispatch.
+"""
+
+import os
+import re
+import sys
+import glob
+import json
+import plistlib
+import subprocess
+from datetime import datetime, timezone
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LAUNCH_AGENTS = os.path.expanduser("~/Library/LaunchAgents")
+DOMAIN = f"gui/{os.getuid()}"
+
+
+def _launchctl_print(label):
+    """Return raw `launchctl print` output for a label, or None if not loaded."""
+    try:
+        out = subprocess.run(
+            ["launchctl", "print", f"{DOMAIN}/{label}"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    return out.stdout if out.returncode == 0 else None
+
+
+def _first(pattern, text, cast=str):
+    m = re.search(pattern, text)
+    if not m:
+        return None
+    try:
+        return cast(m.group(1))
+    except (ValueError, TypeError):
+        return m.group(1)
+
+
+def _log_info(path):
+    """Modification time (ISO) and last few lines of a log file."""
+    if not path or not os.path.exists(path):
+        return None, None
+    mtime = datetime.fromtimestamp(
+        os.path.getmtime(path), tz=timezone.utc
+    ).isoformat()
+    try:
+        with open(path, errors="replace") as f:
+            tail = "".join(f.readlines()[-10:]).strip()
+    except OSError:
+        tail = None
+    return mtime, tail
+
+
+def job_status(label):
+    plist_path = os.path.join(LAUNCH_AGENTS, f"{label}.plist")
+    stdout_path = stderr_path = None
+    if os.path.exists(plist_path):
+        try:
+            with open(plist_path, "rb") as f:
+                pl = plistlib.load(f)
+            stdout_path = pl.get("StandardOutPath")
+            stderr_path = pl.get("StandardErrorPath")
+        except (OSError, plistlib.InvalidFileException):
+            pass
+
+    info = _launchctl_print(label)
+    log_mtime, log_tail = _log_info(stdout_path)
+    return {
+        "label": label,
+        "loaded": info is not None,
+        "state": _first(r"\bstate = (\S+.*)", info) if info else None,
+        "pid": _first(r"\bpid = (\d+)", info, int) if info else None,
+        "last_exit_code": _first(r"last exit code = (-?\d+)", info, int) if info else None,
+        "plist_path": plist_path if os.path.exists(plist_path) else None,
+        "stdout_path": stdout_path,
+        "stderr_path": stderr_path,
+        "last_run": log_mtime,
+        "log_tail": log_tail,
+    }
+
+
+def latest_workout():
+    """Newest workout JSON in data/, summarised for the dashboard."""
+    files = sorted(glob.glob(os.path.join(REPO, "data", "workout_*.json")))
+    if not files:
+        return None
+    path = files[-1]
+    try:
+        with open(path) as f:
+            d = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    date = d.get("workout_date")
+    image = os.path.join(REPO, "images", f"workout_{date}_ig.png") if date else None
+    summary = d.get("summary", {})
+    return {
+        "date": date,
+        "day_of_week": d.get("day_of_week"),
+        "title": d.get("workout_title"),
+        "total_exercises": d.get("total_exercises"),
+        "total_calories": summary.get("total_workout_calories"),
+        "total_volume_lbs": summary.get("total_volume_lbs"),
+        "json_path": path,
+        "image_path": image if image and os.path.exists(image) else None,
+    }
+
+
+def discover_labels():
+    labels = []
+    for path in sorted(glob.glob(os.path.join(LAUNCH_AGENTS, "com.troyscott.*.plist"))):
+        labels.append(os.path.basename(path)[: -len(".plist")])
+    return labels
+
+
+def main():
+    labels = sys.argv[1:] or discover_labels()
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "host": os.uname().nodename,
+        "jobs": [job_status(label) for label in labels],
+        "latest_workout": latest_workout(),
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Give the launchd job(s) that Cowork Dispatch manages from the phone a **status view**. A live artifact can only *display* — it can't run shell — so the pattern is: **Dispatch runs the command, the artifact renders the result.** This adds the machine-readable status surface + a dashboard to render it.

## What

- **`scripts/status.py`** — emits JSON for every `com.troyscott.*` LaunchAgent: load state, last exit code, pid, last run time, and a log tail (parsed from `launchctl print` + the job's `StandardOutPath`). Also includes the latest workout summary (date, title, exercises, calories, volume, image path) parsed from `data/`. Multi-job aware; pass explicit labels or let it discover.
- **`scripts/dashboard.html`** — self-contained dark dashboard template (no external deps) with a `__STATUS_JSON__` injection point.
- **`scripts/dashboard.sh`** — runs `status.py` and injects the JSON into the template → `logs/dashboard.html`. Re-run to refresh.

## Preview

Rendered against the live job (job loaded, exit 0, last run 7m ago, latest workout Fri Jun 5):

![dashboard](https://github.com/troyscott/virtualgym-agent/blob/feat/status-dashboard/scripts/dashboard.html)

(Screenshot shared in chat — shows the job card with EXIT 0 badge, state/last-run/pid stats, log tail, and the latest-workout panel.)

## Verified

- `status.py` produces valid JSON on this Mac mini (`Troys-Mac-mini`), correctly reflecting the installed `com.troyscott.virtualgym.extract` job (loaded, exit 0) and the latest workout.
- `dashboard.sh` renders `logs/dashboard.html`; embedded `DATA` parses as JSON and the injection token is fully replaced.

## Notes

- `logs/` is gitignored, so the rendered `dashboard.html` is a local artifact (the template + renderer are tracked).
- Extends cleanly to other launchd jobs you add under the `com.troyscott.*` label convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only monitoring and local HTML generation; no changes to extraction, auth, or launchd job definitions.
> 
> **Overview**
> Adds a **launchd status surface** for Cowork Dispatch: machine-readable JSON plus a self-contained HTML dashboard you refresh by re-running a script.
> 
> **`scripts/status.py`** discovers `com.troyscott.*` LaunchAgents (or accepts explicit labels), parses `launchctl print` and plist log paths for load state, PID, last exit code, last-run time, and a stdout tail, and attaches a **latest workout** summary from `data/workout_*.json` (including image path when present).
> 
> **`scripts/dashboard.sh`** runs `status.py` and replaces `__STATUS_JSON__` in **`scripts/dashboard.html`** to write **`logs/dashboard.html`** (default). The template is a dark, dependency-free UI with job cards and a workout panel.
> 
> **AGENTS.md**, **CLAUDE.md**, and **README.md** document the dashboard command and the Dispatch pattern: Dispatch runs `dashboard.sh`; the artifact only displays the rendered HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0e998c83e368292a1888046c322c75dc1a2514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->