### PR TITLE
Gitignore .env (keep .env.example trackable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Auth state (contains session cookies)
 virtuagym-auth.json
 
+# Local env secrets (keep .env.example as the trackable template)
+.env
+!.env.example
+
 # Generated output (keep dirs via .gitkeep)
 data/*
 !data/.gitkeep


### PR DESCRIPTION
`.env` holds real secrets and was **not** ignored. Confirmed it was never committed (no leak), but ignoring it removes the risk of an accidental `git add`. `.env.example` stays trackable as the template.

Salvages the still-valid half of the now-closed #14.

## Verified
- `git check-ignore .env` → ignored
- `git check-ignore .env.example` → not ignored (still trackable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no application or secret-handling logic changes.
> 
> **Overview**
> Adds **`.gitignore` rules** so local **`.env`** (secrets) is never committed, while **`.env.example`** remains trackable as the shared template via `!.env.example`.
> 
> This is a preventive hygiene change only; it does not alter runtime config loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4596014a4229ec61199257dec7fcb20aa17d6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->