### PR TITLE
Add WatchPaths Dispatch trigger (sandbox-safe phone trigger)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ images/*
 # launchd job logs
 logs/
 
+# Dispatch trigger file (launchd WatchPaths target)
+.dispatch-trigger
+
 # Fonts tracked in repo (Poppins, OFL licensed)
 
 # Legacy Cowork/Chrome MCP prompts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,37 +72,54 @@ default. Keys: `CHROME_BIN`, `CHROME_PROFILE_DIR` (default `~/.virtuagym-chrome`
 
 ## Running from iPhone (Cowork Dispatch)
 
-Dispatch executes **on this Mac mini** (the phone is just the remote control), so it has full
-access to the local Chrome profile and `localhost:9222` — unlike cloud agents/routines, which are
-isolated and cannot run this workflow.
+Dispatch sessions run on this Mac mini, but their shell is a **sandboxed Linux VM**: no
+`launchctl`, no macOS binaries, and the network allowlist blocks `localhost:9222`. What the
+sandbox DOES have is a **read/write mount of this repo**. The bridge is launchd's `WatchPaths`:
+the job watches `.dispatch-trigger`, so any write to that file — including one made through the
+Cowork mount — fires the extraction natively on the Mac.
 
-`extract.sh` is the single command both the phone and launchd use:
+```
+phone → Dispatch (sandbox) → write .dispatch-trigger → launchd (Mac) → extract.sh → tail logs/ via mount
+```
+
+`extract.sh` is the single entry point for terminal and launchd use:
 
 ```bash
-./extract.sh            # most recent workout (default)
+./extract.sh                  # most recent workout (default)
 ./extract.sh today
 ./extract.sh 2026-06-05
+./extract.sh --from-trigger   # launchd entry point: reads the date arg from .dispatch-trigger
 ```
 
-The extraction is registered as an **on-demand launchd job** (no timer) so it can be triggered and
-monitored via `launchctl` — the natural surface for Dispatch and for a status artifact:
+`scripts/launchd.sh` subcommands, by where they can run:
 
 ```bash
-scripts/launchd.sh install     # register the job (one-time)
-scripts/launchd.sh run-now     # trigger an extraction (launchctl kickstart)
+# Sandbox-safe (pure file I/O — works from Cowork Dispatch)
+scripts/launchd.sh trigger [last|today|YYYY-MM-DD]   # write .dispatch-trigger -> launchd fires
+scripts/launchd.sh logs [N]                          # tail logs/extract.{out,err}.log
+
+# Mac terminal only (need launchctl)
+scripts/launchd.sh install     # register the job (one-time; re-run after plist changes)
+scripts/launchd.sh run-now     # launchctl kickstart
 scripts/launchd.sh status      # load state / last exit code / pid
-scripts/launchd.sh logs [N]    # tail logs (default 40 lines) -> logs/extract.{out,err}.log
 scripts/launchd.sh uninstall
 ```
+
+`extract.sh` never writes `.dispatch-trigger` (that would re-fire WatchPaths and loop); it reads
+it only when invoked with `--from-trigger`, so manual runs are unaffected by stale trigger content.
 
 **Status dashboard (live artifact):** `scripts/status.py` emits JSON for every `com.troyscott.*`
 launchd job (load state, last exit code, last run, log tail) plus the latest workout summary.
 `scripts/dashboard.sh` injects that JSON into `scripts/dashboard.html` and writes a self-contained
 `logs/dashboard.html` — open it, send it to the phone, or surface it as a Cowork live artifact.
-Re-run `dashboard.sh` (via Dispatch) to refresh; the artifact displays, Dispatch executes.
+`extract.sh` re-renders the dashboard at the end of every run, so Dispatch just reads the file
+(`dashboard.sh`/`status.py` themselves need `launchctl`, so they only run on the Mac).
 
-**Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh run-now`,
-then `scripts/launchd.sh logs` until it prints Done!, and send me `images/workout_<date>_ig.png`."*
+**Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh trigger`,
+then `scripts/launchd.sh logs` until it prints Done!, then **attach the file**
+`images/workout_<date>_ig.png` so it appears in Outputs (share the actual file, not just a
+description)."* The explicit "attach the file" matters — Dispatch only surfaces files the agent
+actively shares, so narrating "here's your image" without attaching leaves Outputs empty.
 
 Requirements: the Mac mini stays awake/networked and Claude Desktop is running and signed in. If the
 Google session ever dies, the headless run can't solve the login unattended — re-run

--- a/README.md
+++ b/README.md
@@ -106,22 +106,37 @@ python3 extract_workout.py "Mar 21"
 
 ### Run from your phone (Cowork Dispatch)
 
-`extract.sh` wraps the command so it works from a single entry point, and the extraction can be
-registered as an on-demand launchd job and triggered/monitored via `launchctl` — ideal for Cowork
-Dispatch, which runs locally on the Mac and so can reach the Chrome profile + `localhost:9222`:
+Cowork Dispatch runs in a **sandboxed Linux VM** — no `launchctl`, no macOS binaries, and
+`localhost:9222` is blocked — but it has a **read/write mount of this repo**. The bridge is launchd's
+`WatchPaths`: the on-demand job watches `.dispatch-trigger`, so writing that file (which the sandbox
+can do through the mount) fires `extract.sh` **natively on the Mac**, where Chrome lives.
 
-```bash
-./extract.sh                   # most recent workout
-scripts/launchd.sh install     # register the on-demand launchd job (one-time)
-scripts/launchd.sh run-now     # trigger it; logs -> logs/extract.{out,err}.log
-scripts/launchd.sh status      # load state / last exit code
-scripts/launchd.sh logs        # tail recent output
-scripts/dashboard.sh           # render logs/dashboard.html status dashboard (live artifact)
+```
+phone → Dispatch (sandbox) → write .dispatch-trigger → launchd (Mac) → extract.sh → outputs + logs via mount
 ```
 
-`scripts/status.py` emits JSON for every `com.troyscott.*` launchd job plus the latest workout
-summary; `scripts/dashboard.sh` injects it into a self-contained HTML dashboard you can view, send to
-your phone, or surface as a Cowork live artifact.
+`scripts/launchd.sh` subcommands, by where they can run:
+
+```bash
+# Sandbox-safe (pure file I/O — works from Cowork Dispatch)
+scripts/launchd.sh trigger [last|today|YYYY-MM-DD]   # write .dispatch-trigger -> launchd fires
+scripts/launchd.sh logs [N]                          # tail logs/extract.{out,err}.log
+
+# Mac terminal only (need launchctl)
+scripts/launchd.sh install     # register the on-demand job (one-time; re-run after plist changes)
+scripts/launchd.sh run-now     # launchctl kickstart
+scripts/launchd.sh status      # load state / last exit code / pid
+scripts/launchd.sh uninstall
+```
+
+`extract.sh` re-renders `logs/dashboard.html` at the end of every run (`scripts/status.py` +
+`scripts/dashboard.sh`, which themselves need `launchctl` so they only run on the Mac), so Dispatch
+can read a current status dashboard straight from the mount.
+
+**Phone recipe:** *"In virtualgym-agent, run `scripts/launchd.sh trigger`, then `scripts/launchd.sh
+logs` until it prints Done!, then **attach the file** `images/workout_<date>_ig.png` so it appears in
+Outputs (share the actual file, not just a description)."* The explicit "attach the file" matters —
+Dispatch only surfaces files the agent actively shares.
 
 The script will:
 1. Load saved auth and open the VirtuaGym Activity Calendar

--- a/extract.sh
+++ b/extract.sh
@@ -3,9 +3,11 @@
 # Thin wrapper so the phone (Cowork Dispatch) and launchd can run the
 # extraction with a single, environment-independent command:
 #
-#     ./extract.sh            # most recent workout (default)
+#     ./extract.sh                  # most recent workout (default)
 #     ./extract.sh today
 #     ./extract.sh 2026-06-05
+#     ./extract.sh --from-trigger   # launchd WatchPaths entry point: read the
+#                                   # date arg from .dispatch-trigger
 #
 set -euo pipefail
 
@@ -25,4 +27,21 @@ if [ ! -x "$PYTHON" ]; then
     exit 1
 fi
 
-exec "$PYTHON" extract_workout.py "${1:-last}"
+# Resolve the date argument. --from-trigger (the launchd WatchPaths job) reads
+# it from .dispatch-trigger so the Cowork sandbox can pass a date by writing
+# the file. READ-ONLY here: writing the trigger from this script would re-fire
+# WatchPaths and loop.
+ARG="${1:-last}"
+if [ "$ARG" = "--from-trigger" ]; then
+    ARG="$(head -n1 .dispatch-trigger 2>/dev/null | xargs || true)"
+    ARG="${ARG:-last}"
+fi
+
+rc=0
+"$PYTHON" extract_workout.py "$ARG" || rc=$?
+
+# Refresh the status dashboard (best-effort) so Dispatch can read a current
+# logs/dashboard.html without needing launchctl.
+scripts/dashboard.sh >/dev/null 2>&1 || true
+
+exit "$rc"

--- a/scripts/launchd.sh
+++ b/scripts/launchd.sh
@@ -2,15 +2,23 @@
 #
 # Manage the VirtuaGym extraction as an on-demand launchd job (LaunchAgent).
 #
-# The job has no timed trigger — it runs only when you kick it off, which is
-# ideal for triggering from the phone via Cowork Dispatch. Dispatch runs
-# locally, so it can call any of these subcommands:
+# The job has no timed trigger — it runs on demand, two ways:
 #
-#     scripts/launchd.sh install     # register the job with launchd
-#     scripts/launchd.sh run-now     # trigger an extraction now
-#     scripts/launchd.sh status      # show load state / last exit code / pid
-#     scripts/launchd.sh logs [N]    # tail the last N log lines (default 40)
-#     scripts/launchd.sh uninstall   # remove the job
+#   1. launchctl kickstart (`run-now`) — requires a real Mac shell.
+#   2. WatchPaths on .dispatch-trigger — ANY process that can write to the repo
+#      (incl. Cowork's sandboxed Linux shell, which has no launchctl and no
+#      localhost access but mounts the repo read/write) fires the job by
+#      writing the trigger file. This is the Cowork Dispatch path.
+#
+# Sandbox-safe (pure file I/O):
+#     scripts/launchd.sh trigger [ARG]   # write .dispatch-trigger (ARG: last|today|YYYY-MM-DD)
+#     scripts/launchd.sh logs [N]        # tail the last N log lines (default 40)
+#
+# Mac-terminal only (need launchctl):
+#     scripts/launchd.sh install         # register the job with launchd
+#     scripts/launchd.sh run-now         # kickstart an extraction now
+#     scripts/launchd.sh status          # show load state / last exit code / pid
+#     scripts/launchd.sh uninstall       # remove the job
 #
 set -euo pipefail
 
@@ -19,6 +27,7 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG_DIR="$REPO/logs"
 PLIST_DST="$HOME/Library/LaunchAgents/$LABEL.plist"
 DOMAIN="gui/$(id -u)"
+TRIGGER="$REPO/.dispatch-trigger"
 
 gen_plist() {
     mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
@@ -32,12 +41,16 @@ gen_plist() {
     <key>ProgramArguments</key>
     <array>
         <string>$REPO/extract.sh</string>
-        <string>last</string>
+        <string>--from-trigger</string>
     </array>
     <key>WorkingDirectory</key>
     <string>$REPO</string>
     <key>RunAtLoad</key>
     <false/>
+    <key>WatchPaths</key>
+    <array>
+        <string>$TRIGGER</string>
+    </array>
     <key>StandardOutPath</key>
     <string>$LOG_DIR/extract.out.log</string>
     <key>StandardErrorPath</key>
@@ -49,11 +62,13 @@ PLIST
 
 case "${1:-}" in
     install)
+        # Pre-create the trigger file so loading the job doesn't fire it.
+        [ -f "$TRIGGER" ] || : > "$TRIGGER"
         gen_plist
         launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
         launchctl bootstrap "$DOMAIN" "$PLIST_DST"
         echo "Installed $LABEL (on-demand)."
-        echo "Trigger it with: $0 run-now"
+        echo "Trigger it with: $0 run-now  (or, from a sandbox: $0 trigger [last|today|DATE])"
         ;;
     uninstall)
         launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || true
@@ -63,6 +78,12 @@ case "${1:-}" in
     run-now)
         launchctl kickstart -k "$DOMAIN/$LABEL"
         echo "Triggered $LABEL. Follow output with: $0 logs"
+        ;;
+    trigger)
+        # Sandbox-safe trigger: a write to the watched file makes launchd run
+        # the job. No launchctl needed — works from Cowork Dispatch.
+        echo "${2:-last}" > "$TRIGGER"
+        echo "Wrote $TRIGGER (${2:-last}). launchd will start the job; follow with: $0 logs"
         ;;
     status)
         if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
@@ -80,7 +101,7 @@ case "${1:-}" in
         done
         ;;
     *)
-        echo "Usage: $0 {install|uninstall|run-now|status|logs [N]}" >&2
+        echo "Usage: $0 {install|uninstall|run-now|trigger [ARG]|status|logs [N]}" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Why

Triggering the extraction from the phone via Cowork Dispatch didn't work the way the docs assumed. **Dispatch runs in a sandboxed Linux VM** — no `launchctl`, no macOS binaries, and `localhost:9222` is blocked — so it can't kickstart the launchd job or reach Chrome directly. It *does* have a **read/write mount of the repo**.

## How

Bridge the sandbox to the Mac with launchd **`WatchPaths`**: the on-demand job watches `.dispatch-trigger`; the sandbox fires the native extraction by writing that file through the mount.

```
phone → Dispatch (sandbox) → write .dispatch-trigger → launchd (Mac) → extract.sh → outputs + logs via mount
```

- **`scripts/launchd.sh`** — `WatchPaths` on `.dispatch-trigger` in the generated plist; sandbox-safe `trigger [ARG]` subcommand (pure file write); pre-creates the trigger on `install`; `ProgramArguments` → `extract.sh --from-trigger`.
- **`extract.sh`** — `--from-trigger` reads the date from `.dispatch-trigger` (**read-only**, so a run never re-fires WatchPaths), then best-effort re-renders `logs/dashboard.html` so Dispatch can read current status without `launchctl`.
- **`.gitignore`** — ignore `.dispatch-trigger` (runtime artifact; `install` recreates it).
- **`README.md` / `CLAUDE.md`** — corrected Dispatch model (sandbox VM + WatchPaths), with the by-where-it-runs subcommand split. The phone recipe now says to **explicitly attach** the image file — Dispatch only surfaces files the agent actively shares, so narrating "here's your image" leaves Outputs empty.

## Verified end-to-end

A real dispatched session wrote `.dispatch-trigger` (14:34); launchd ran `extract.sh --from-trigger` natively → "Done!" + regenerated JSON + IG image (14:35), exit 0. No self-trigger loop (trigger mtime unchanged across the run).

## Known gap (docs/follow-up)

The exact Cowork mechanism for surfacing a file to the **Outputs** panel isn't publicly documented. Observed: the session must *explicitly attach* the file; merely generating/mentioning it doesn't surface it. Recipe wording updated accordingly; if explicit-attach proves unreliable, fallback is out-of-band delivery (Dropbox/Photos) from the Mac side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the launchd job is started (WatchPaths + trigger file) and who can fire runs from the phone; extraction and auth paths are unchanged, with explicit loop-avoidance on the trigger file.
> 
> **Overview**
> Enables **phone-triggered workout extraction** when Cowork Dispatch runs in a sandbox that cannot use `launchctl` or reach Chrome on `localhost:9222`. The launchd job now watches **`.dispatch-trigger`**; writing that file through the repo mount starts **`extract.sh --from-trigger`** on the Mac, which reads the date from the first line of the trigger (default `last`).
> 
> **`scripts/launchd.sh`** adds a sandbox-safe **`trigger [ARG]`** command, registers **`WatchPaths`** on the trigger in the generated plist (replacing a fixed `last` argument), and pre-creates an empty trigger on **`install`** so loading the job does not fire a run. **`extract.sh`** only **reads** the trigger (avoids re-firing WatchPaths), preserves the Python exit code, and **best-effort refreshes** `logs/dashboard.html` after each run so Dispatch can read status from the mount without `launchctl`.
> 
> **`.gitignore`** ignores `.dispatch-trigger`. **README** and **CLAUDE.md** document the corrected Dispatch/sandbox model, split **sandbox-safe** vs **Mac-only** subcommands, and update the phone recipe to **attach** the IG PNG file for Outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb256c2b63f1cec1c5f5c4b371348e384e09af20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->