### PR TITLE
Dedup WatchPaths multi-fire + deliver IG image to stable path and Dropbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,11 @@ images/*
 # launchd job logs
 logs/
 
-# Dispatch trigger file (launchd WatchPaths target)
-.dispatch-trigger
+# Dispatch trigger file (launchd WatchPaths target) + dedup state
+.dispatch-trigger*
+
+# Single-run lock dir (atomic mkdir lock)
+/.extract.lock
 
 # Fonts tracked in repo (Poppins, OFL licensed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,19 @@ launchd job (load state, last exit code, last run, log tail) plus the latest wor
 `extract.sh` re-renders the dashboard at the end of every run, so Dispatch just reads the file
 (`dashboard.sh`/`status.py` themselves need `launchctl`, so they only run on the Mac).
 
+**Image delivery:** on success `extract.sh` copies the IG image to a stable `images/latest_ig.png`
+**and** to `~/Dropbox/virtuagym/` (override `VIRTUAGYM_DROPBOX_DIR`). Dropbox is the guaranteed channel
+(view via the Dropbox app/connector), independent of Dispatch's file-sharing.
+
+**Trigger de-dup:** one `.dispatch-trigger` write emits several FSEvents; `extract.sh --from-trigger`
+fingerprints the trigger (mtime + content via `.dispatch-trigger.processed`) and skips duplicate fires,
+plus a `.extract.lock` mkdir lock prevents overlapping runs. One write → exactly one extraction.
+
 **Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh trigger`,
-then `scripts/launchd.sh logs` until it prints Done!, then **attach the file**
-`images/workout_<date>_ig.png` so it appears in Outputs (share the actual file, not just a
-description)."* The explicit "attach the file" matters — Dispatch only surfaces files the agent
-actively shares, so narrating "here's your image" without attaching leaves Outputs empty.
+then `scripts/launchd.sh logs` until it prints Done!, then **attach the file** `images/latest_ig.png`
+so it appears in Outputs (share the actual file, not just a description)."* The explicit "attach the
+file" matters — Dispatch only surfaces files the agent actively shares; narrating "here's your image"
+leaves Outputs empty. Fallback: pull the image from the Dropbox `virtuagym/` folder.
 
 Requirements: the Mac mini stays awake/networked and Claude Desktop is running and signed in. If the
 Google session ever dies, the headless run can't solve the login unattended — re-run

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ with an env var without editing the file.
 | `CDP_PORT` | `9222` | Remote debugging port |
 | `VIRTUAGYM_SIGNIN_URL` / `VIRTUAGYM_CALENDAR_URL` | thriveandconquer.virtuagym.com URLs | VirtuaGym endpoints |
 | `VIRTUAGYM_GOOGLE_ACCOUNT` | `troys2005@gmail.com` | Account shown in the sign-in prompt |
+| `VIRTUAGYM_DROPBOX_DIR` | `~/Dropbox/virtuagym` | Where `extract.sh` copies the IG image (skipped if no `~/Dropbox`) |
 
 ### 4. Refresh auth (if expired)
 
@@ -133,10 +134,20 @@ scripts/launchd.sh uninstall
 `scripts/dashboard.sh`, which themselves need `launchctl` so they only run on the Mac), so Dispatch
 can read a current status dashboard straight from the mount.
 
+**Image delivery:** on a successful run `extract.sh` copies the IG image to a stable path
+(`images/latest_ig.png`) **and** to `~/Dropbox/virtuagym/` (override with `VIRTUAGYM_DROPBOX_DIR`).
+The Dropbox copy is the guaranteed channel — view it in the Dropbox app/connector on the phone,
+independent of whether Dispatch can attach files.
+
+**Trigger de-duplication:** a single `.dispatch-trigger` write can emit several FSEvents, so
+`extract.sh --from-trigger` fingerprints the trigger (mtime + content) and ignores duplicate fires; a
+mkdir lock also prevents overlapping runs. One write → exactly one extraction.
+
 **Phone recipe:** *"In virtualgym-agent, run `scripts/launchd.sh trigger`, then `scripts/launchd.sh
-logs` until it prints Done!, then **attach the file** `images/workout_<date>_ig.png` so it appears in
-Outputs (share the actual file, not just a description)."* The explicit "attach the file" matters —
-Dispatch only surfaces files the agent actively shares.
+logs` until it prints Done!, then **attach the file** `images/latest_ig.png` so it appears in Outputs
+(share the actual file, not just a description)."* The explicit "attach the file" matters — Dispatch
+only surfaces files the agent actively shares. If it still won't surface, grab the image from the
+Dropbox `virtuagym/` folder instead.
 
 The script will:
 1. Load saved auth and open the VirtuaGym Activity Calendar

--- a/extract.sh
+++ b/extract.sh
@@ -9,10 +9,18 @@
 #     ./extract.sh --from-trigger   # launchd WatchPaths entry point: read the
 #                                   # date arg from .dispatch-trigger
 #
+# On success it copies the generated IG image to a stable path
+# (images/latest_ig.png) and to ~/Dropbox/virtuagym/ so it can be retrieved
+# from the phone regardless of Dispatch's file-sharing.
+#
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
+REPO="$SCRIPT_DIR"
+TRIGGER="$REPO/.dispatch-trigger"
+PROCESSED="$REPO/.dispatch-trigger.processed"
+LOCK="$REPO/.extract.lock"
 
 # launchd runs jobs with a minimal PATH; agent-browser lives in Homebrew's bin.
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:${PATH:-}"
@@ -31,14 +39,57 @@ fi
 # it from .dispatch-trigger so the Cowork sandbox can pass a date by writing
 # the file. READ-ONLY here: writing the trigger from this script would re-fire
 # WatchPaths and loop.
+FROM_TRIGGER=0
 ARG="${1:-last}"
 if [ "$ARG" = "--from-trigger" ]; then
-    ARG="$(head -n1 .dispatch-trigger 2>/dev/null | xargs || true)"
+    FROM_TRIGGER=1
+    ARG="$(head -n1 "$TRIGGER" 2>/dev/null | xargs || true)"
     ARG="${ARG:-last}"
+fi
+
+# Single-run lock (atomic mkdir — macOS has no flock). Prevents overlapping runs
+# from a near-simultaneous WatchPaths multi-fire or a manual run colliding with
+# a triggered one on the same Chrome profile.
+if mkdir "$LOCK" 2>/dev/null; then
+    trap 'rmdir "$LOCK" 2>/dev/null || true' EXIT
+else
+    [ "$FROM_TRIGGER" = 1 ] && exit 0   # another run in progress; this fire is redundant
+    echo "Another extraction is already running (lock: $LOCK). Exiting." >&2
+    exit 1
+fi
+
+# Dedup duplicate WatchPaths fires: a single write to .dispatch-trigger emits
+# several FSEvents, so launchd may start the job more than once. Fingerprint the
+# trigger (mtime + content); if it matches the last processed one, this is a
+# duplicate fire — skip. A genuine re-trigger is a new write (new mtime), so it
+# still runs. (Writing .dispatch-trigger.processed does NOT re-fire WatchPaths:
+# the plist watches the exact .dispatch-trigger path, not the directory.)
+if [ "$FROM_TRIGGER" = 1 ]; then
+    fp="$(stat -f '%m' "$TRIGGER" 2>/dev/null || true)|$(head -n1 "$TRIGGER" 2>/dev/null || true)"
+    if [ -f "$PROCESSED" ] && [ "$fp" = "$(cat "$PROCESSED" 2>/dev/null || true)" ]; then
+        echo "Duplicate trigger fire (unchanged $TRIGGER); skipping."
+        exit 0
+    fi
+    printf '%s\n' "$fp" > "$PROCESSED"
 fi
 
 rc=0
 "$PYTHON" extract_workout.py "$ARG" || rc=$?
+
+# Deliver the freshest IG image to a stable path + Dropbox so the phone can
+# always retrieve it (best-effort — never fail the run on a copy error).
+if [ "$rc" -eq 0 ]; then
+    newest="$(ls -t images/workout_*_ig.png 2>/dev/null | head -1 || true)"
+    if [ -n "$newest" ]; then
+        cp -f "$newest" images/latest_ig.png 2>/dev/null || true
+        dropbox_dir="${VIRTUAGYM_DROPBOX_DIR:-$HOME/Dropbox/virtuagym}"
+        if [ -d "$HOME/Dropbox" ]; then
+            mkdir -p "$dropbox_dir" 2>/dev/null || true
+            cp -f "$newest" "$dropbox_dir/" 2>/dev/null || true
+            cp -f "$newest" "$dropbox_dir/latest_ig.png" 2>/dev/null || true
+        fi
+    fi
+fi
 
 # Refresh the status dashboard (best-effort) so Dispatch can read a current
 # logs/dashboard.html without needing launchctl.


### PR DESCRIPTION
Fixes two issues found in live Cowork Dispatch testing of the WatchPaths trigger (#20).

## 1. Trigger fired the job 3× on one write
A non-atomic `.dispatch-trigger` write emits several FSEvents, so launchd started the job multiple times (identical output, but wasteful and risks overlapping Chrome/CDP runs).

**Fix:** `extract.sh --from-trigger` fingerprints the trigger (`mtime + content` → `.dispatch-trigger.processed`) and skips duplicate fires; an atomic `mkdir` lock (`.extract.lock`, since macOS has no `flock`) prevents overlapping runs. A genuine re-trigger is a new write (new mtime) so it still runs. **One write → exactly one extraction.**

## 2. IG image never reached the phone
The dispatched agent couldn't attach it — it looked at `data/images/…` (which doesn't exist; images live at `images/`), and Dispatch's file-share-to-Outputs path is undocumented.

**Fix:** on success `extract.sh` copies the freshest image to a **stable `images/latest_ig.png`** (so the prompt can always attach one known path) **and** to **`~/Dropbox/virtuagym/`** (`VIRTUAGYM_DROPBOX_DIR`, skipped if no `~/Dropbox`). Dropbox is the guaranteed channel, independent of Dispatch's attach mechanism.

## Verified (Mac)
- `scripts/launchd.sh trigger last` → **single** `Done!`; `images/latest_ig.png` refreshed; `~/Dropbox/virtuagym/` has `workout_2026-06-05_ig.png` + `latest_ig.png`.
- Repeat fire of the same trigger → "Duplicate trigger fire … skipping", exits in ~0.02s (no extraction).
- New write (new mtime/content) → would run (not deduped).
- No stale lock; err log clean.

## Docs
README + CLAUDE.md: recipe now attaches `images/latest_ig.png`, documents Dropbox delivery + `VIRTUAGYM_DROPBOX_DIR`, and the dedup/lock behavior. `.gitignore`: `.dispatch-trigger*` + `/.extract.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration around concurrent extractions and trigger dedup; a logic bug could skip a real trigger, but overlapping runs on the shared Chrome profile was the main operational risk being addressed.
> 
> **Overview**
> **`extract.sh`** now treats Cowork Dispatch’s launchd **WatchPaths** path as one extraction per trigger write: an atomic **`mkdir` lock** (`.extract.lock`) blocks overlapping Chrome runs, and **`--from-trigger`** dedupes repeated FSEvents by fingerprinting **mtime + first line** into `.dispatch-trigger.processed` (duplicate fires exit quietly; a new write still runs).
> 
> On **success**, the newest `images/workout_*_ig.png` is copied to **`images/latest_ig.png`** and, when `~/Dropbox` exists, to **`~/Dropbox/virtuagym/`** (including `latest_ig.png`; override **`VIRTUAGYM_DROPBOX_DIR`**). Copies are best-effort and do not fail the run.
> 
> **Docs** (`README.md`, `CLAUDE.md`) document stable attach path, Dropbox fallback, dedup/lock behavior, and the new config key. **`.gitignore`** ignores `.dispatch-trigger*` and `/.extract.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99bc2ffe10e94fcfee278bf90de8efb865e8f1bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->