### PR TITLE
Add tracked outputs/ folder as the Dispatch delivery location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ data/*
 images/*
 !images/.gitkeep
 
+# Stable delivery folder for Dispatch (tracked dir, ignored contents)
+outputs/*
+!outputs/.gitkeep
+
 # launchd job logs
 logs/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,16 +115,18 @@ launchd job (load state, last exit code, last run, log tail) plus the latest wor
 `extract.sh` re-renders the dashboard at the end of every run, so Dispatch just reads the file
 (`dashboard.sh`/`status.py` themselves need `launchctl`, so they only run on the Mac).
 
-**Image delivery:** on success `extract.sh` copies the IG image to a stable `images/latest_ig.png`
+**Image delivery:** on success `extract.sh` copies the IG image to **`outputs/`** (git-tracked folder,
+visible in the Dispatch repo mount → agent attaches `outputs/latest_ig.png` to the Outputs panel)
 **and** to `~/Dropbox/virtuagym/` (override `VIRTUAGYM_DROPBOX_DIR`). Dropbox is the guaranteed channel
-(view via the Dropbox app/connector), independent of Dispatch's file-sharing.
+(view via the Dropbox app/connector), independent of Dispatch's file-sharing. `outputs/` is tracked via
+`.gitkeep`; its images are gitignored.
 
 **Trigger de-dup:** one `.dispatch-trigger` write emits several FSEvents; `extract.sh --from-trigger`
 fingerprints the trigger (mtime + content via `.dispatch-trigger.processed`) and skips duplicate fires,
 plus a `.extract.lock` mkdir lock prevents overlapping runs. One write → exactly one extraction.
 
 **Phone recipe:** dispatch something like *"In virtualgym-agent, run `scripts/launchd.sh trigger`,
-then `scripts/launchd.sh logs` until it prints Done!, then **attach the file** `images/latest_ig.png`
+then `scripts/launchd.sh logs` until it prints Done!, then **attach the file** `outputs/latest_ig.png`
 so it appears in Outputs (share the actual file, not just a description)."* The explicit "attach the
 file" matters — Dispatch only surfaces files the agent actively shares; narrating "here's your image"
 leaves Outputs empty. Fallback: pull the image from the Dropbox `virtuagym/` folder.

--- a/README.md
+++ b/README.md
@@ -134,17 +134,19 @@ scripts/launchd.sh uninstall
 `scripts/dashboard.sh`, which themselves need `launchctl` so they only run on the Mac), so Dispatch
 can read a current status dashboard straight from the mount.
 
-**Image delivery:** on a successful run `extract.sh` copies the IG image to a stable path
-(`images/latest_ig.png`) **and** to `~/Dropbox/virtuagym/` (override with `VIRTUAGYM_DROPBOX_DIR`).
-The Dropbox copy is the guaranteed channel — view it in the Dropbox app/connector on the phone,
-independent of whether Dispatch can attach files.
+**Image delivery:** on a successful run `extract.sh` copies the IG image to **`outputs/`** (a
+git-tracked folder, so it's visible in the Dispatch repo mount as `outputs/latest_ig.png` for the
+agent to attach to the Outputs panel) **and** to `~/Dropbox/virtuagym/` (override with
+`VIRTUAGYM_DROPBOX_DIR`). The Dropbox copy is the guaranteed channel — view it in the Dropbox
+app/connector on the phone, independent of whether Dispatch can attach files. (`outputs/` is tracked
+via `.gitkeep`; the images inside it are gitignored.)
 
 **Trigger de-duplication:** a single `.dispatch-trigger` write can emit several FSEvents, so
 `extract.sh --from-trigger` fingerprints the trigger (mtime + content) and ignores duplicate fires; a
 mkdir lock also prevents overlapping runs. One write → exactly one extraction.
 
 **Phone recipe:** *"In virtualgym-agent, run `scripts/launchd.sh trigger`, then `scripts/launchd.sh
-logs` until it prints Done!, then **attach the file** `images/latest_ig.png` so it appears in Outputs
+logs` until it prints Done!, then **attach the file** `outputs/latest_ig.png` so it appears in Outputs
 (share the actual file, not just a description)."* The explicit "attach the file" matters — Dispatch
 only surfaces files the agent actively shares. If it still won't surface, grab the image from the
 Dropbox `virtuagym/` folder instead.

--- a/extract.sh
+++ b/extract.sh
@@ -76,12 +76,18 @@ fi
 rc=0
 "$PYTHON" extract_workout.py "$ARG" || rc=$?
 
-# Deliver the freshest IG image to a stable path + Dropbox so the phone can
-# always retrieve it (best-effort — never fail the run on a copy error).
+# Deliver the freshest IG image so the phone can always retrieve it (best-effort
+# — never fail the run on a copy error). Two channels:
+#   1. outputs/ — a git-tracked folder, so it's visible in the Dispatch repo
+#      mount; the agent attaches outputs/latest_ig.png to the Outputs panel.
+#   2. ~/Dropbox/virtuagym/ — guaranteed channel, viewable in the Dropbox app.
 if [ "$rc" -eq 0 ]; then
     newest="$(ls -t images/workout_*_ig.png 2>/dev/null | head -1 || true)"
     if [ -n "$newest" ]; then
-        cp -f "$newest" images/latest_ig.png 2>/dev/null || true
+        mkdir -p outputs 2>/dev/null || true
+        cp -f "$newest" "outputs/$(basename "$newest")" 2>/dev/null || true
+        cp -f "$newest" outputs/latest_ig.png 2>/dev/null || true
+
         dropbox_dir="${VIRTUAGYM_DROPBOX_DIR:-$HOME/Dropbox/virtuagym}"
         if [ -d "$HOME/Dropbox" ]; then
             mkdir -p "$dropbox_dir" 2>/dev/null || true


### PR DESCRIPTION
## Why

The Dispatch sandbox can read the **repo mount** but not `~/Dropbox`, so for the agent to attach the IG image to the **Outputs** panel it needs a stable, mount-visible path. (Dropbox stays as the guaranteed human channel, but it can't feed Outputs.)

## What

- **`outputs/`** — a git-tracked folder (`.gitkeep` tracked, images gitignored) so it exists in the repo mount the sandbox sees.
- **`extract.sh`** — on success copies the IG image to `outputs/latest_ig.png` + `outputs/workout_<date>_ig.png`, **and** still to `~/Dropbox/virtuagym/`.
- **Docs/recipe** — the Dispatch attach now targets `outputs/latest_ig.png`.

## Verified (Mac)

- Triggered run → single `Done!`; `outputs/` has `latest_ig.png` + dated image; `~/Dropbox/virtuagym/` has them too.
- `git check-ignore outputs/latest_ig.png` → ignored; only `outputs/.gitkeep` is tracked.

## Next (phone)

Re-dispatch: *"run `scripts/launchd.sh trigger`, wait for Done!, then attach `outputs/latest_ig.png`."* If it now lands in the Outputs panel, that's the supported flow; Dropbox remains the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort post-success file copies only; core extraction and Dropbox delivery are unchanged.
> 
> **Overview**
> Moves the **Dispatch-visible IG image delivery** from gitignored `images/latest_ig.png` to a tracked **`outputs/`** directory so Cowork agents can attach `outputs/latest_ig.png` from the repo mount into the Outputs panel.
> 
> **`extract.sh`** still copies the newest `images/workout_*_ig.png` on success, but now writes **`outputs/<dated>_ig.png`** and **`outputs/latest_ig.png`** instead of updating `images/latest_ig.png`. The **Dropbox** copy under `~/Dropbox/virtuagym/` is unchanged.
> 
> **`.gitignore`** ignores `outputs/*` while keeping **`outputs/.gitkeep`** tracked. **README** and **CLAUDE** phone recipes now tell Dispatch to attach **`outputs/latest_ig.png`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb56cdced5e23a2c94f297848a21580bd8dff17b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->