### PR TITLE
Drop VirtuaGym activity rows from the exercise list

### DIFF
--- a/extract_workout.py
+++ b/extract_workout.py
@@ -577,6 +577,19 @@ def main():
         sets_desc = f"{len(detail['sets'])} sets"
         print(f"{sets_desc}, {detail['total_calories']} Kcal")
 
+    # Drop VirtuaGym session "activity" rows (e.g. "Fitness, strength training/
+    # bodybuilding"). These aren't exercises and have no detail panel of their
+    # own, so the click-through reads stale set/calorie values from the previous
+    # exercise — inflating volume, calories, and counts. Remove them after the
+    # loop so per-order classification of the real exercises is unaffected.
+    def is_activity_row(name):
+        return name.strip().lower().startswith("fitness,")
+
+    dropped = [e for e in exercises if is_activity_row(e["name"])]
+    for e in dropped:
+        print(f"  Dropping activity row (not an exercise): {e['name']}")
+    exercises = [e for e in exercises if not is_activity_row(e["name"])]
+
     # Step 4: Calculate volume
     total_volume, volume_breakdown = calculate_volume(exercises)
 


### PR DESCRIPTION
## Problem

VirtuaGym logs a session **activity** row — e.g. *"Fitness, strength training/bodybuilding"* — that isn't a real exercise and has no detail panel of its own. When `extract_exercise_detail` clicked it, the panel still showed the **previous** exercise's data, so the row was saved with stale sets/calories.

On Jun 5 this produced a phantom entry byte-identical to **Slam ball - MB** (`14/6/12 @ 14 lbs`, 24 Kcal), which **double-counted in the totals**: +448 lbs volume and +24 Kcal, and inflated the exercise count.

## Fix

After the extraction loop, drop rows whose name starts with `fitness,` (VirtuaGym's `Fitness, <activity>` session label). Doing it *after* the loop means per-order classification of the real exercises is untouched; `calculate_volume`, calorie sum, and counts all recompute from the filtered list.

## Verified (Jun 5 re-run)

| | before | after |
|---|---|---|
| exercises | 15 | **14** |
| calories | 246 | **222** |
| volume (lbs) | 4,706 | **4,258** |
| conditioning | 8 | **7** |

`volume_breakdown` no longer contains the phantom "Fitness … 448"; the regenerated IG image ends at Slam ball. Legit L/R variants (Split front squat left/right) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to extraction output filtering with no auth or persistence logic changes; misclassification risk is limited to names matching the `fitness,` prefix.
> 
> **Overview**
> **Fixes inflated workout totals** when VirtuaGym’s sidebar includes a session **activity** label (e.g. `Fitness, strength training/bodybuilding`) that is not a real exercise.
> 
> After the per-exercise click-through loop, **`extract_workout.py` now filters out** rows whose name starts with `fitness,` (case-insensitive), logs each dropped row, and only then runs **volume**, **calorie sum**, and **warmup/strength/conditioning counts**. Filtering happens *after* extraction so **order-based classification** for actual exercises is unchanged.
> 
> This avoids saving **stale sets/calories** from the previous exercise’s detail panel, which had been **double-counting volume and calories** in JSON, reports, and IG output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb61108d1de17c9d52f4719f09d2a3713f1f9124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->