### PR TITLE
Fix docs drift: structure tree, env path, AX rotation, schema example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,44 +9,50 @@ Automated workout extraction from VirtuaGym Activity Calendar using Vercel's `ag
 ## Project Structure
 
 ```
-workouts/
-├── requirements.txt          # Python dependencies (pip)
-├── extract_workout.py        # Main extraction script (run this)
+virtualgym-agent/
+├── ARCHITECTURE.md           # System design, data flow, decision rationale
+├── extract.sh                # Single entry point (terminal + launchd); dedup, delivery
+├── extract_workout.py        # Main extraction pipeline
 ├── browser_session.py        # Persistent Chrome profile + CDP connect/login
 ├── generate_ig_workout.py    # Pillow-based IG image generator
+├── config.json               # Browser/VirtuaGym settings (committed, no secrets)
+├── requirements.txt          # Python dependencies (pip)
+├── scripts/
+│   ├── launchd.sh            # LaunchAgent manager (install/run-now/trigger/status/logs)
+│   ├── status.py             # JSON status for com.troyscott.* jobs + latest workout
+│   └── dashboard.{html,sh}   # Live-artifact status dashboard -> logs/dashboard.html
 ├── fonts/                    # Poppins font files
-├── data/                     # JSON + text reports
-│   ├── workout_YYYY-MM-DD.json
-│   └── workout_YYYY-MM-DD_report.txt
-├── images/                   # Generated Instagram images
-│   └── workout_YYYY-MM-DD_ig.png
-└── prompts/                  # Archived Cowork/Chrome MCP prompts
+├── data/                     # JSON + text reports (gitignored)
+├── images/                   # Generated Instagram images (gitignored)
+├── outputs/                  # Delivery folder for Dispatch (tracked dir, ignored contents)
+└── logs/                     # launchd job logs + dashboard.html (gitignored)
 ```
 
 ## Python Environment
 
-Uses micromamba with the `workout` env at `~/.local/share/mamba/envs/workout`.
+Uses micromamba with the `workout` env at `/opt/homebrew/Cellar/micromamba/2.5.0_4/envs/workout`
+(Homebrew Cellar path — it moves on micromamba upgrades; `extract.sh` hardcodes it but honors a
+`WORKOUT_PYTHON` env override pointing at the env's `python`).
 
 ```bash
 micromamba create -n workout python=3.12 -c conda-forge -y
-micromamba activate workout
-pip install -r requirements.txt
+micromamba run -n workout pip install -r requirements.txt
+
+# Run scripts via the env without activating:
+micromamba run -n workout python extract_workout.py last
 ```
 
 ## Quick Start
 
 ```bash
-micromamba activate workout
+# Simplest: the wrapper resolves the env python and PATH itself
+./extract.sh                  # most recent workout (default)
+./extract.sh today
+./extract.sh 2026-03-21
 
-# Extract today's workout (default)
-python3 extract_workout.py
-
-# Extract the most recent workout on the calendar
-python3 extract_workout.py last
-
-# Extract a specific date
-python3 extract_workout.py 2026-03-21
-
+# Or call the pipeline directly via the env
+micromamba run -n workout python extract_workout.py        # today (default)
+micromamba run -n workout python extract_workout.py last
 # Other formats: today, yesterday, "Mar 21", "3/21"
 ```
 
@@ -173,12 +179,12 @@ No weight:               volume = 0
 {
   "workout_date": "YYYY-MM-DD",
   "day_of_week": "DayName",
-  "workout_title": "Troy Scott AV – X – Name",
-  "total_exercises": 12,
+  "workout_title": "Troy Scott AX - 1 - Squat/Pull",
+  "total_exercises": 14,
   "extraction_timestamp": "ISO-8601",
   "source": "thriveandconquer.virtuagym.com",
-  "activity": { "name": "Steps", "value": 12944, "unit": "steps", "duration": "HH:MM:SS", "calories": 614 },
-  "additional_activities": [{ "name": "Activity", "duration": "HH:MM:SS", "calories": 205 }],
+  "activity": null,
+  "additional_activities": [],
   "exercises": [{
     "order": 1, "name": "Exercise Name", "type": "warmup", "category": "activation",
     "exercise_mode": "repetition-based",
@@ -186,23 +192,32 @@ No weight:               volume = 0
     "total_calories": 7
   }],
   "summary": {
-    "total_workout_calories": 278, "total_with_steps": 892,
-    "warmup_count": 5, "strength_count": 2, "conditioning_count": 5,
-    "total_volume_lbs": 10155, "volume_breakdown": { "Exercise": 3660 }
+    "total_workout_calories": 222, "total_with_steps": 222,
+    "steps_calories": 0, "additional_activity_calories": 0,
+    "warmup_count": 5, "strength_count": 2, "conditioning_count": 7,
+    "total_volume_lbs": 4258, "volume_breakdown": { "Exercise": 3060 },
+    "volume_note": "Time-based exercises use seconds as reps per VirtuaGym"
   }
 }
 ```
 
 - Time-based sets: `"reps": null, "duration": "40s"`
 - Rep-based sets: `"reps": 10, "duration": null`
+- `activity` is currently always `null` — "Steps" comes through as exercise 1 (with no sets); the
+  reserved `activity`/`additional_activities` fields are kept for future use
+- VirtuaGym session activity rows (names starting `"Fitness,"`) are dropped during extraction —
+  they have no detail panel and would duplicate the previous exercise's sets (see #23)
 
 ## Workout Rotation
 
 Two alternating programs, typically 2-3x/week:
 
-**AV-1 Squat/Pull**: Dead bug, Scapular pull up, Side pivot, Horizontal row exorotation, Sumo squat stretch > Squat (Barbell), Hammer curl (DBs) > Step up high (DBs), Bent-over row (DBs), Crunch crossed toe touch, Rowing machine, Wall ball (MB)
+**AX-1 Squat/Pull**: Dead bug, Scapular pull up (Rig), Side pivot (MRB), Horizontal row exorotation (EBs), Sumo squat stretch rotation > Squat (Barbell) > Plank jacks (Flowin), Assisted standing pull up wide grip, Split front squat L/R (Barbell), Squat to hammer curl (DBs), Wide back row (ST), Slam ball (MB)
 
-**AV-2 Press/Hinge**: Neck pull (EB), Hand walk plyo pushup, Pallof press R/L (Pulley), Goodmorning > Bench press wide grip (Barbell), Deadlift stiffed legs (DBs) > Push-up incline (PB), Swing (KB), Sit-up overhead throw (Wall MB), Assault bike, Push press alternated (LM)
+**AX-2 Press/Hinge**: Neck pull (EB), Hand walk plyo pushup, Pallof press R/L (Pulley) > Goodmorning, Bench press wide grip (Barbell) > Knee raise side (Captains chair), Assisted dipping machine, Stiff legged deadlift (Barbell), Side raise seated (DBs), Hang clean press L/R (KB), Forward push (Sled)
+
+(Earlier AV-1/AV-2 programs are retired; "Steps" appears as entry 1 on every workout as the day's
+step-count activity.)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,20 @@ Works standalone via CLI, or integrated with Claude Channels, OpenClaw, and othe
 
 ### 1. Python environment (micromamba)
 
-Create and activate the `workout` environment:
+Create the `workout` environment and install dependencies:
 
 ```bash
 micromamba create -n workout python=3.12 -c conda-forge -y
-micromamba activate workout
-pip install -r requirements.txt
+micromamba run -n workout pip install -r requirements.txt
 ```
 
-The environment lives at `~/.local/share/mamba/envs/workout`. Activate it before running any scripts:
+With Homebrew micromamba the env lives under the Cellar (e.g.
+`/opt/homebrew/Cellar/micromamba/<version>/envs/workout`) — note this path moves on micromamba
+upgrades. `extract.sh` resolves the env's python itself and honors a `WORKOUT_PYTHON` override if
+yours lives elsewhere. To run scripts directly:
 
 ```bash
-micromamba activate workout
+micromamba run -n workout python extract_workout.py last
 ```
 
 ### 2. Install agent-browser
@@ -170,25 +172,31 @@ The script will:
 ## Project Structure
 
 ```
-workouts/
+virtualgym-agent/
 ├── README.md                 # This file
 ├── CLAUDE.md                 # Claude Code project context
-├── requirements.txt          # Python dependencies (pip)
-├── extract_workout.py        # Main extraction script (agent-browser)
+├── ARCHITECTURE.md           # System design, data flow, decision rationale
+├── extract.sh                # Single entry point (terminal + launchd); dedup, delivery
+├── extract_workout.py        # Main extraction pipeline (agent-browser)
 ├── browser_session.py        # Persistent Chrome profile + CDP connect/login
 ├── generate_ig_workout.py    # Pillow-based IG image generator
+├── config.json               # Browser/VirtuaGym settings (committed, no secrets)
+├── requirements.txt          # Python dependencies (pip)
+├── scripts/                  # launchd.sh, status.py, dashboard.{html,sh}
 ├── fonts/                    # Poppins font files for image generation
 ├── data/                     # JSON reports and text summaries (gitignored)
-└── images/                   # Generated Instagram images (gitignored)
+├── images/                   # Generated Instagram images (gitignored)
+├── outputs/                  # Delivery folder for Dispatch (tracked dir, ignored contents)
+└── logs/                     # launchd job logs + dashboard.html (gitignored)
 ```
 
 ## Workout Programs
 
 Two alternating programs, typically 2-3x/week:
 
-- **AV-1 Squat/Pull**: Dead bug, Scapular pull up, Side pivot, Horizontal row exorotation, Sumo squat stretch > Squat (Barbell), Hammer curl (DBs) > Step up high (DBs), Bent-over row (DBs), Crunch crossed toe touch, Rowing machine, Wall ball (MB)
+- **AX-1 Squat/Pull**: Dead bug, Scapular pull up (Rig), Side pivot (MRB), Horizontal row exorotation (EBs), Sumo squat stretch rotation > Squat (Barbell) > Plank jacks (Flowin), Assisted standing pull up wide grip, Split front squat L/R (Barbell), Squat to hammer curl (DBs), Wide back row (ST), Slam ball (MB)
 
-- **AV-2 Press/Hinge**: Neck pull (EB), Hand walk plyo pushup, Pallof press R/L (Pulley), Goodmorning > Bench press wide grip (Barbell), Deadlift stiffed legs (DBs) > Push-up incline (PB), Swing (KB), Sit-up overhead throw (Wall MB), Assault bike, Push press alternated (LM)
+- **AX-2 Press/Hinge**: Neck pull (EB), Hand walk plyo pushup, Pallof press R/L (Pulley) > Goodmorning, Bench press wide grip (Barbell) > Knee raise side (Captains chair), Assisted dipping machine, Stiff legged deadlift (Barbell), Side raise seated (DBs), Hang clean press L/R (KB), Forward push (Sled)
 
 ## Volume Calculation
 

--- a/extract.sh
+++ b/extract.sh
@@ -10,7 +10,7 @@
 #                                   # date arg from .dispatch-trigger
 #
 # On success it copies the generated IG image to a stable path
-# (images/latest_ig.png) and to ~/Dropbox/virtuagym/ so it can be retrieved
+# (outputs/latest_ig.png) and to ~/Dropbox/virtuagym/ so it can be retrieved
 # from the phone regardless of Dispatch's file-sharing.
 #
 set -euo pipefail


### PR DESCRIPTION
Closes #25.

A doc review against the live system found the operational sections (auth, Dispatch/WatchPaths, delivery, troubleshooting) accurate — the drift was all in sections predating last week's work.

## Changes

- **Project Structure** (CLAUDE.md + README): reflects the actual layout — `extract.sh`, `scripts/`, `outputs/`, `config.json`, `ARCHITECTURE.md`, `logs/`; root label fixed (`workouts/` → `virtualgym-agent/`); gitignored legacy `prompts/` dropped from the tree.
- **Python environment** (CLAUDE.md + README): corrected env path (Homebrew Cellar, not `~/.local/share/mamba` — verified the old path doesn't exist), noted the Cellar path moves on micromamba upgrades, documented the `WORKOUT_PYTHON` override; Quick Start now leads with `./extract.sh` and uses `micromamba run -n workout`.
- **Workout Rotation** (CLAUDE.md + README): retired **AV-1/AV-2** replaced with the current **AX-1 Squat/Pull** / **AX-2 Press/Hinge** lists, sourced from actual extractions (Jun 5 / Jun 7).
- **JSON schema example** (CLAUDE.md): matches real output — `activity: null` (Steps is exercise 1), full `summary` keys, and a note that `"Fitness,"` activity rows are dropped (#23).
- **`extract.sh`**: header comment corrected (`images/` → `outputs/` — the delivery path shipped in #22).
- **Local hygiene** (not in diff): deleted the legacy gitignored `virtuagym-auth.json` (expired cookie snapshot, superseded by the persistent CDP profile, #15).

## Deliberately left out

`.env.example` remains untracked: the local `.env*` permission rule prevents me from inspecting it, and this is a public repo — I won't publish a file I can't read. To track it, give it a quick glance and `git add .env.example && git commit` (or adjust the permission rule to allow `.env.example` and I'll do it).

## Data note

AX-2 extractions show two `Hang clean press, left - KB` entries (#12/#13) — the second is presumably `right` mislabeled **in VirtuaGym**, matching the known R/L pattern. Fix is a rename in VirtuaGym, not in the extractor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and a shell comment only; no runtime or extraction logic changes.
> 
> **Overview**
> **Documentation-only** alignment with the live **virtualgym-agent** layout and current extraction output (closes #25).
> 
> **CLAUDE.md** and **README.md** now describe the real repo tree (`virtualgym-agent/`, `extract.sh`, `scripts/`, `outputs/`, `config.json`, `ARCHITECTURE.md`, `logs/`) instead of the old `workouts/` sketch. Python setup docs switch from `~/.local/share/mamba` to the Homebrew Cellar path, document `WORKOUT_PYTHON`, and lead Quick Start with `./extract.sh` / `micromamba run -n workout`. Workout rotation text replaces retired **AV-1/AV-2** with **AX-1** / **AX-2** lists; the JSON schema example and notes match current output (`activity: null`, full `summary` keys, `"Fitness,"` rows dropped).
> 
> **extract.sh** header comment only: stable IG copy path documented as `outputs/latest_ig.png` (behavior already matched the script).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535b8e94cfbd326101dc6b20d8091d1de9e22c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->