### PR TITLE
Track .env.example (env template)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# MongoDB Atlas connection
+# Get from: Atlas > Cluster > Connect > Drivers (Python)
+MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/?retryWrites=true&w=majority&appName=<appName>
+MONGODB_DB=virtualgym
+MONGODB_WORKOUTS_COLLECTION=workouts


### PR DESCRIPTION
Adds the `.env.example` template to version control — a sample MongoDB connection string (owner-confirmed placeholder, no real credentials). The real `.env` remains gitignored (`.gitignore` already has `.env` + `!.env.example`).

Completes the item deliberately deferred from #25/#26 pending owner confirmation of the file's contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only env template with placeholders; no runtime or credential changes.
> 
> **Overview**
> Adds a tracked **`.env.example`** template so new contributors know which environment variables to set for MongoDB Atlas.
> 
> The file documents **`MONGODB_URI`**, **`MONGODB_DB`**, and **`MONGODB_WORKOUTS_COLLECTION`** with placeholder connection-string values (no real credentials). Actual secrets stay in gitignored **`.env`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c747e24c50875019425dfc460cf6d87483bcd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->